### PR TITLE
Suggested changes

### DIFF
--- a/common.go
+++ b/common.go
@@ -5,7 +5,6 @@ package main
 
 import (
 	"fmt"
-	"github.com/fatih/color"
 	"os/exec"
 	"regexp"
 	"strings"
@@ -25,9 +24,9 @@ func exeCmd(cmd string, wg *sync.WaitGroup) string {
 
 	out, err := exec.Command(head, parts...).Output()
 	if err != nil {
-		color.Red("%s", err)
+		errmsg("%s", err)
 	}
-	color.Yellow("%s", out)
+	warn("%s", out)
 	wg.Done()
 	return string(out)
 }


### PR DESCRIPTION
Don't use the color stuff everywhere. Define three functions which use those
colors, but have more useful names, such as errormsg, warn, and msg.

printUsage exits, but that's confusing to have something named print do an exit.
I changed it to usage.

For usage, just change os.Args[0] and call flag.Usage, it can be more convenient.

Signed-off-by: Ron Minnich <rminnich@gmail.com>